### PR TITLE
Redesign premium dark color system

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,20 +4,40 @@
   --white: #ffffff;
   --purple: #6200ea;
   --purple-deep: #3700b3;
+  --purple-primary: #7c3cff;
+  --purple-hover: #9463ff;
+  --purple-active: #5422cc;
+  --purple-glow: #b388ff;
+  --purple-subtle: #180a2f;
+  --accent-reward: #35f2a0;
+  --accent-reward-deep: #0fbf7a;
+  --accent-mystery: #ffb238;
+  --accent-mystery-deep: #d67d00;
+  --bg-void: #000000;
+  --bg-night: #08030f;
+  --bg-orbit: #120522;
+  --bg-panel: #17111f;
   --panel: #333333;
-  --panel-soft: rgba(51, 51, 51, 0.82);
-  --panel-strong: rgba(20, 20, 24, 0.92);
-  --line: rgba(255, 255, 255, 0.14);
-  --muted: rgba(255, 255, 255, 0.72);
-  --danger: #ff4d4d;
-  --success: #1db954;
-  --shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  --panel-soft: rgba(23, 17, 31, 0.86);
+  --panel-strong: rgba(10, 5, 18, 0.94);
+  --line: rgba(229, 221, 255, 0.16);
+  --line-strong: rgba(179, 136, 255, 0.32);
+  --text-primary: #f7f2ff;
+  --text-secondary: #c9b8ef;
+  --text-muted: #8f82aa;
+  --text-disabled: #5b526d;
+  --text-inverse: #09040f;
+  --danger: #ff5c7a;
+  --success: var(--accent-reward);
+  --warning: var(--accent-mystery);
+  --muted: var(--text-secondary);
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.58);
   --radius-lg: 28px;
   --radius-md: 18px;
   --radius-sm: 12px;
   --header-h: 72px;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: var(--black);
+  background: var(--bg-void);
 }
 
 * {
@@ -25,19 +45,18 @@
 }
 
 html {
-  background: var(--black);
+  background: var(--bg-void);
 }
 
 body {
   min-width: 320px;
   min-height: 100dvh;
   margin: 0;
-  color: var(--white);
+  color: var(--text-primary);
   background:
-    radial-gradient(circle at 18% 10%, rgba(98, 0, 234, 0.36), transparent 34rem),
-    radial-gradient(circle at 86% 18%, rgba(98, 0, 234, 0.18), transparent 28rem),
-    linear-gradient(135deg, rgba(98, 0, 234, 0.1), transparent 44%),
-    var(--black);
+    radial-gradient(circle at 16% 8%, rgba(124, 60, 255, 0.34), transparent 34rem),
+    radial-gradient(circle at 88% 14%, rgba(255, 178, 56, 0.14), transparent 26rem),
+    linear-gradient(140deg, var(--bg-void) 0%, var(--bg-night) 38%, var(--bg-orbit) 100%);
   overflow-x: hidden;
 }
 
@@ -86,7 +105,7 @@ img {
   justify-content: space-between;
   gap: 1rem;
   padding: max(0.85rem, env(safe-area-inset-top)) clamp(1rem, 3vw, 2rem) 0.85rem;
-  background: linear-gradient(90deg, rgba(98, 0, 234, 0.95), rgba(55, 0, 179, 0.95));
+  background: linear-gradient(92deg, rgba(8, 3, 15, 0.92) 0%, rgba(55, 0, 179, 0.88) 48%, rgba(124, 60, 255, 0.86) 100%);
   border-bottom: 1px solid rgba(255,255,255,0.16);
   box-shadow: 0 12px 40px rgba(0,0,0,0.34);
   backdrop-filter: blur(18px);
@@ -116,7 +135,7 @@ img {
   font-size: 0.72rem;
   letter-spacing: 0.13em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.72);
+  color: var(--text-secondary);
 }
 
 h1,
@@ -190,7 +209,7 @@ h3 {
   inset: auto -10% -22% auto;
   width: 22rem;
   aspect-ratio: 1;
-  background: radial-gradient(circle, rgba(98,0,234,0.36), transparent 68%);
+  background: radial-gradient(circle, rgba(179,136,255,0.3), transparent 68%);
   pointer-events: none;
 }
 
@@ -225,13 +244,13 @@ h3 {
 }
 
 .status-pill.solved {
-  background: rgba(29, 185, 84, 0.17);
-  border-color: rgba(29, 185, 84, 0.45);
+  background: rgba(53, 242, 160, 0.16);
+  border-color: rgba(53, 242, 160, 0.46);
 }
 
 .status-pill.failed {
-  background: rgba(255, 77, 77, 0.17);
-  border-color: rgba(255, 77, 77, 0.45);
+  background: rgba(255, 92, 122, 0.16);
+  border-color: rgba(255, 92, 122, 0.46);
 }
 
 .attempts {
@@ -252,18 +271,18 @@ h3 {
 }
 
 .attempt-dot.used {
-  background: var(--purple);
-  box-shadow: 0 0 20px rgba(98,0,234,0.65);
+  background: var(--purple-primary);
+  box-shadow: 0 0 20px rgba(179,136,255,0.62);
 }
 
 .attempt-dot.used.solved {
   background: var(--success);
-  box-shadow: 0 0 20px rgba(29,185,84,0.45);
+  box-shadow: 0 0 20px rgba(53,242,160,0.45);
 }
 
 .attempt-dot.used.failed {
   background: var(--danger);
-  box-shadow: 0 0 20px rgba(255,77,77,0.45);
+  box-shadow: 0 0 20px rgba(255,92,122,0.45);
 }
 
 .panel-counter,
@@ -280,8 +299,8 @@ h3 {
   border-radius: var(--radius-lg);
   border: 1px solid rgba(255,255,255,0.12);
   background:
-    radial-gradient(circle at 50% 0%, rgba(98,0,234,0.24), transparent 52%),
-    rgba(0,0,0,0.36);
+    radial-gradient(circle at 50% 0%, rgba(124,60,255,0.24), transparent 52%),
+    linear-gradient(180deg, rgba(18,5,34,0.62), rgba(0,0,0,0.42));
   overflow: hidden;
 }
 
@@ -320,10 +339,10 @@ h3 {
   max-width: min(88%, 38rem);
   padding: 0.78rem 0.9rem;
   border-radius: 1rem;
-  background: rgba(98, 0, 234, 0.84);
-  border: 1px solid rgba(255,255,255,0.2);
-  box-shadow: 0 12px 30px rgba(0,0,0,0.38);
-  color: var(--white);
+  background: rgba(255, 178, 56, 0.2);
+  border: 1px solid rgba(255, 178, 56, 0.42);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.38), 0 0 28px rgba(255,178,56,0.14);
+  color: var(--text-primary);
   font-weight: 750;
   backdrop-filter: blur(10px);
 }
@@ -345,7 +364,7 @@ h3 {
 .progress-rail span {
   inset-inline-start: 0;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--purple), #8d4dff);
+  background: linear-gradient(90deg, var(--purple-primary), var(--accent-reward));
   transition: inline-size 240ms ease;
 }
 
@@ -361,11 +380,11 @@ h3 {
 }
 
 .result-message.ok {
-  color: #67ff9a;
+  color: var(--accent-reward);
 }
 
 .result-message.no {
-  color: #ff8a8a;
+  color: var(--danger);
 }
 
 .guess-form {
@@ -382,13 +401,13 @@ h3 {
   border: 1px solid var(--line);
   outline: none;
   background: rgba(0,0,0,0.36);
-  color: var(--white);
+  color: var(--text-primary);
   transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .guess-form input:focus {
-  border-color: rgba(98, 0, 234, 0.9);
-  box-shadow: 0 0 0 4px rgba(98,0,234,0.22);
+  border-color: rgba(148, 99, 255, 0.95);
+  box-shadow: 0 0 0 4px rgba(124,60,255,0.24);
   background: rgba(0,0,0,0.5);
 }
 
@@ -399,16 +418,16 @@ h3 {
   min-height: 2.75rem;
   border: 0;
   border-radius: var(--radius-sm);
-  color: var(--white);
+  color: var(--text-primary);
   font-weight: 850;
   cursor: pointer;
-  transition: transform 120ms ease, background 160ms ease, border-color 160ms ease, opacity 160ms ease;
+  transition: transform 120ms ease, background 160ms ease, border-color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
 
 .primary-button {
   padding: 0.75rem 1rem;
-  background: linear-gradient(135deg, var(--purple), var(--purple-deep));
-  box-shadow: 0 16px 34px rgba(98,0,234,0.36);
+  background: linear-gradient(135deg, var(--purple-primary), var(--purple-deep));
+  box-shadow: 0 16px 34px rgba(124,60,255,0.36), 0 0 28px rgba(179,136,255,0.16);
 }
 
 .ghost-button {
@@ -434,8 +453,8 @@ h3 {
 
 .danger-button {
   padding: 0.72rem 0.9rem;
-  background: rgba(255, 77, 77, 0.18);
-  border: 1px solid rgba(255, 77, 77, 0.38);
+  background: rgba(255, 92, 122, 0.18);
+  border: 1px solid rgba(255, 92, 122, 0.38);
 }
 
 .primary-button:not(:disabled):hover,
@@ -445,11 +464,20 @@ h3 {
   transform: translateY(-1px);
 }
 
+.primary-button:not(:disabled):hover {
+  background: linear-gradient(135deg, var(--purple-hover), var(--purple-primary));
+  box-shadow: 0 18px 38px rgba(148,99,255,0.4), 0 0 32px rgba(179,136,255,0.2);
+}
+
 .primary-button:not(:disabled):active,
 .ghost-button:not(:disabled):active,
 .icon-button:not(:disabled):active,
 .danger-button:not(:disabled):active {
   transform: translateY(1px) scale(0.99);
+}
+
+.primary-button:not(:disabled):active {
+  background: linear-gradient(135deg, var(--purple-active), var(--purple-deep));
 }
 
 .controls-row {
@@ -488,7 +516,7 @@ h3 {
   padding: 1rem;
   overflow: auto;
   background:
-    radial-gradient(circle at 15% 0%, rgba(98,0,234,0.26), transparent 26rem),
+    radial-gradient(circle at 15% 0%, rgba(124,60,255,0.26), transparent 26rem),
     var(--panel-strong);
   border-left: 1px solid var(--line);
   box-shadow: -24px 0 80px rgba(0,0,0,0.55);
@@ -538,7 +566,7 @@ h3 {
 .history-row {
   width: 100%;
   border: 1px solid var(--line);
-  color: var(--white);
+  color: var(--text-primary);
   background: rgba(255,255,255,0.07);
   text-align: left;
   cursor: pointer;
@@ -557,12 +585,12 @@ h3 {
 .history-row:hover {
   transform: translateY(-1px);
   background: rgba(255,255,255,0.1);
-  border-color: rgba(98,0,234,0.7);
+  border-color: rgba(148,99,255,0.72);
 }
 
 .level-card.active {
-  border-color: rgba(98,0,234,0.95);
-  box-shadow: inset 0 0 0 1px rgba(98,0,234,0.55), 0 0 34px rgba(98,0,234,0.18);
+  border-color: rgba(179,136,255,0.92);
+  box-shadow: inset 0 0 0 1px rgba(124,60,255,0.55), 0 0 34px rgba(179,136,255,0.2);
 }
 
 .level-number {
@@ -572,7 +600,7 @@ h3 {
   width: 2.55rem;
   height: 2.55rem;
   border-radius: 0.9rem;
-  background: rgba(98,0,234,0.36);
+  background: rgba(124,60,255,0.28);
   font-weight: 900;
 }
 
@@ -634,9 +662,9 @@ h3 {
 .warning-card {
   padding: 0.9rem 1rem;
   border-radius: var(--radius-md);
-  color: #fff5d7;
-  background: rgba(255, 178, 36, 0.18);
-  border: 1px solid rgba(255, 178, 36, 0.38);
+  color: #fff2d1;
+  background: rgba(255, 178, 56, 0.16);
+  border: 1px solid rgba(255, 178, 56, 0.4);
 }
 
 .history-list {
@@ -692,7 +720,7 @@ h3 {
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: rgba(16,16,18,0.96);
+  background: rgba(10,5,18,0.96);
   box-shadow: var(--shadow);
 }
 
@@ -712,8 +740,8 @@ h3 {
   aspect-ratio: 1;
   border: 1px solid rgba(255,255,255,0.2);
   border-radius: 999px;
-  background: rgba(98,0,234,0.9);
-  color: var(--white);
+  background: rgba(124,60,255,0.9);
+  color: var(--text-primary);
   font-weight: 900;
   cursor: pointer;
 }
@@ -732,7 +760,7 @@ h3 {
   aspect-ratio: 1;
   border-radius: 50%;
   border: 4px solid rgba(255,255,255,0.15);
-  border-top-color: var(--purple);
+  border-top-color: var(--purple-glow);
   animation: spin 800ms linear infinite;
 }
 
@@ -804,7 +832,7 @@ h3 {
     bottom: 0;
     z-index: 5;
     padding: 0.55rem 0 0;
-    background: linear-gradient(to top, rgba(36,36,38,0.96), rgba(36,36,38,0.72), transparent);
+    background: linear-gradient(to top, rgba(10,5,18,0.96), rgba(18,5,34,0.72), transparent);
   }
 
   .controls-row .ghost-button {


### PR DESCRIPTION
### Motivation
- Refresh the app's visual system to a premium, modern dark game UI while keeping purple as the core brand anchor and preserving legacy tokens (`#000000`, `#ffffff`, `#6200ea`, `#3700b3`, `#333333`).
- Provide a clearer color taxonomy (primary brand states, reward and mystery accents, dark background tokens and text hierarchy) to improve emotional engagement and reduce visual noise during repeated play.
- Make the theme tokens explicit and composable so UI components and future theming/backends can rely on a single `:root` palette.

### Description
- Added new CSS variables for the premium purple family and accents including primary/default `--purple-primary: #7c3cff`, hover `--purple-hover: #9463ff`, active `--purple-active: #5422cc`, glow `--purple-glow: #b388ff`, and subtle background `--purple-subtle: #180a2f` along with legacy `--purple` and `--purple-deep` retained.  
- Added two accent families for feedback: reward (`--accent-reward: #35f2a0`, `--accent-reward-deep: #0fbf7a`) and mystery (`--accent-mystery: #ffb238`, `--accent-mystery-deep: #d67d00`).
- Introduced dark background tokens (`--bg-void: #000000`, `--bg-night: #08030f`, `--bg-orbit: #120522`, `--bg-panel: #17111f`) and a full text color hierarchy (`--text-primary: #f7f2ff`, `--text-secondary: #c9b8ef`, `--text-muted: #8f82aa`, `--text-disabled: #5b526d`, `--text-inverse: #09040f`, `--danger: #ff5c7a`, `--success: var(--accent-reward)`, `--warning: var(--accent-mystery)`).
- Applied the palette across the UI: replaced page/background gradients with a black→purple-black gradient plus atmospheric blooms, updated header gradient direction to `92deg`, and styled components such as buttons (default/hover/active states and glows), progress rail, status pills, attempt dots, hint overlays, modals, loader, cards and focus outlines to use the new tokens for consistent affordance and emphasis.  

### Testing
- Ran `npm test` and the test suite completed successfully (Test Files: 1 passed, Tests: 4 passed).  
- Ran `npm run build` and the production build succeeded (Vite build completed).  
- Attempted `npm test -- --runInBand` which failed because Vitest does not accept `--runInBand`, so the flagged invocation is not supported.  
- Attempted an automated Playwright screenshot to capture the updated UI, but the browser download/install failed due to a `403 Forbidden` from the Playwright CDN so the screenshot step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439f1f7e948328a8f84ff202702cbf)