### PR TITLE
Localize UI/messages to English and refresh theme styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,18 @@
 <!doctype html>
-<html lang="it">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#6200ea" />
     <meta
       name="description"
-      content="Guess the Manga: indovina il manga da quattro immagini, scegli i livelli liberamente e conserva i progressi."
+      content="Guess the Manga: guess the manga from four images, choose levels freely, and keep your progress."
     />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <title>Guess the Manga</title>
   </head>
   <body>
-    <noscript>Questa web app richiede JavaScript per funzionare.</noscript>
+    <noscript>This web app requires JavaScript to run.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,12 +129,12 @@ export function App() {
         setLastResult(null);
       }
     } catch (error) {
-      window.alert(`Import fallito: ${error instanceof Error ? error.message : String(error)}`);
+      window.alert(`Import failed: ${error instanceof Error ? error.message : String(error)}`);
     }
   }, []);
 
   const resetProgress = useCallback(async () => {
-    const ok = window.confirm('Vuoi davvero cancellare tutti i progressi locali?');
+    const ok = window.confirm('Do you really want to delete all local progress?');
     if (!ok) return;
     await storeRef.current?.clear();
     const fresh = startOrResumeLevel(createInitialProgress(), firstLevelId);
@@ -147,7 +147,7 @@ export function App() {
     return (
       <div className="loading-screen">
         <div className="loader" />
-        <p>Caricamento progressi…</p>
+        <p>Loading progress…</p>
       </div>
     );
   }

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -39,13 +39,13 @@ export function GameScreen({
   const statusLabel = useMemo(() => {
     switch (progress.status) {
       case 'solved':
-        return 'Risolto';
+        return 'Solved';
       case 'failed':
-        return 'Concluso';
+        return 'Finished';
       case 'playing':
-        return 'In gioco';
+        return 'Playing';
       default:
-        return 'Nuovo';
+        return 'New';
     }
   }, [progress.status]);
 
@@ -54,23 +54,23 @@ export function GameScreen({
       <section className="game-shell glass-card">
         <div className="game-topline">
           <div>
-            <p className="eyebrow">Livello {levelIndex + 1}</p>
+            <p className="eyebrow">Level {levelIndex + 1}</p>
             <h2>{level.title}</h2>
           </div>
           <button className="ghost-button compact" type="button" onClick={onOpenLevels}>
-            Cambia livello
+            Change level
           </button>
         </div>
 
         <div className="status-strip">
           <span className={`status-pill ${progress.status}`}>{statusLabel}</span>
           <AttemptDots used={progress.attemptsUsed} status={progress.status} />
-          <span className="panel-counter">Immagine {progress.currentPanelIndex + 1}/4</span>
+          <span className="panel-counter">Image {progress.currentPanelIndex + 1}/4</span>
         </div>
 
         <div className="panel-stage">
-          <button className="image-button" type="button" onClick={() => setModalOpen(true)} aria-label="Ingrandisci immagine">
-            <img src={currentPanel.src} alt={`Pannello del livello ${levelIndex + 1}, immagine ${progress.currentPanelIndex + 1}`} />
+          <button className="image-button" type="button" onClick={() => setModalOpen(true)} aria-label="Enlarge image">
+            <img src={currentPanel.src} alt={`Level ${levelIndex + 1} panel, image ${progress.currentPanelIndex + 1}`} />
           </button>
           {progress.hintVisible ? <div className="hint-overlay">{currentPanel.hint}</div> : null}
         </div>
@@ -88,7 +88,7 @@ export function GameScreen({
           </p>
         ) : (
           <p className="result-message muted" role="status">
-            Ogni invio, anche vuoto, consuma un tentativo reale.
+            Every submission counts as an attempt.
           </p>
         )}
 
@@ -104,12 +104,12 @@ export function GameScreen({
             value={guess}
             disabled={submitDisabled}
             onChange={(event) => setGuess(event.target.value)}
-            placeholder={isFinished ? 'Livello concluso' : 'Scrivi la risposta o invia vuoto per passare'}
+            placeholder={isFinished ? 'Level finished' : 'Write your answer here'}
             autoComplete="off"
             inputMode="text"
           />
           <button className="primary-button" type="submit" disabled={submitDisabled}>
-            Invia
+            Submit
           </button>
         </form>
 
@@ -117,17 +117,17 @@ export function GameScreen({
           {canRevealControls ? (
             <>
               <button className="ghost-button" type="button" disabled={!canGoPrevious} onClick={() => onPanelChange(progress.currentPanelIndex - 1)}>
-                ← Precedente
+                ← Previous
               </button>
               <button className="ghost-button" type="button" onClick={onToggleHint}>
-                {progress.hintVisible ? 'Nascondi indizio' : 'Mostra indizio'}
+                {progress.hintVisible ? 'Hide hint' : 'Show hint'}
               </button>
               <button className="ghost-button" type="button" disabled={!canGoNext} onClick={() => onPanelChange(progress.currentPanelIndex + 1)}>
-                Successiva →
+                Next →
               </button>
             </>
           ) : (
-            <p className="muted controls-note">Gli indizi e la navigazione fra immagini si sbloccano dopo il primo tentativo.</p>
+            <p className="muted controls-note">After your first attempt, hints will become available.</p>
           )}
         </div>
       </section>
@@ -135,7 +135,7 @@ export function GameScreen({
       {modalOpen ? (
         <ImageModal
           src={currentPanel.src}
-          alt={`Pannello ingrandito del livello ${levelIndex + 1}`}
+          alt={`Enlarged panel for level ${levelIndex + 1}`}
           onClose={() => setModalOpen(false)}
         />
       ) : null}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,18 +7,14 @@ export function Header({ onOpenLevels, onOpenStats }: HeaderProps) {
   return (
     <header className="app-header">
       <div className="brand" aria-label="Guess the Manga">
-        <span className="brand-mark">?</span>
-        <div>
-          <p className="eyebrow">Free local-first game</p>
-          <h1>Guess the Manga</h1>
-        </div>
+        <h1>Guess the Manga</h1>
       </div>
 
-      <nav className="header-actions" aria-label="Navigazione principale">
+      <nav className="header-actions" aria-label="Primary navigation">
         <button className="ghost-button" type="button" onClick={onOpenLevels}>
-          Livelli
+          Levels
         </button>
-        <button className="icon-button" type="button" onClick={onOpenStats} aria-label="Statistiche">
+        <button className="icon-button" type="button" onClick={onOpenStats} aria-label="Statistics">
           <span aria-hidden="true">▦</span>
         </button>
       </nav>

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -20,10 +20,10 @@ export function ImageModal({ src, alt, onClose }: ImageModalProps) {
   }, [onClose]);
 
   return (
-    <div className="image-modal" role="dialog" aria-modal="true" aria-label="Immagine ingrandita">
-      <button className="modal-backdrop" type="button" aria-label="Chiudi immagine" onClick={onClose} />
+    <div className="image-modal" role="dialog" aria-modal="true" aria-label="Enlarged image">
+      <button className="modal-backdrop" type="button" aria-label="Close image" onClick={onClose} />
       <div className="image-modal-card">
-        <button className="modal-close" type="button" onClick={onClose} aria-label="Chiudi">
+        <button className="modal-close" type="button" onClick={onClose} aria-label="Close">
           ✕
         </button>
         <img src={src} alt={alt} />

--- a/src/components/LevelMenu.tsx
+++ b/src/components/LevelMenu.tsx
@@ -17,22 +17,22 @@ export function LevelMenu({ open, levels, progress, activeLevelId, onSelectLevel
   const stats = calculateStats(progress);
 
   return (
-    <aside className="sheet" role="dialog" aria-modal="true" aria-label="Menu livelli">
-      <button className="sheet-backdrop" type="button" aria-label="Chiudi menu livelli" onClick={onClose} />
+    <aside className="sheet" role="dialog" aria-modal="true" aria-label="Level menu">
+      <button className="sheet-backdrop" type="button" aria-label="Close level menu" onClick={onClose} />
       <div className="sheet-panel">
         <div className="sheet-header">
           <div>
-            <p className="eyebrow">Scegli liberamente</p>
-            <h2>Livelli</h2>
+            <p className="eyebrow">Choose freely</p>
+            <h2>Levels</h2>
           </div>
-          <button className="icon-button" type="button" onClick={onClose} aria-label="Chiudi">
+          <button className="icon-button" type="button" onClick={onClose} aria-label="Close">
             ✕
           </button>
         </div>
 
-        <div className="mini-stats" aria-label="Riepilogo progressi">
-          <span>{stats.solved}/{stats.total} risolti</span>
-          <span>{stats.usedAttempts} tentativi usati</span>
+        <div className="mini-stats" aria-label="Progress summary">
+          <span>{stats.solved}/{stats.total} solved</span>
+          <span>{stats.usedAttempts} attempts used</span>
           <span>{stats.completionPct}%</span>
         </div>
 
@@ -63,12 +63,12 @@ export function LevelMenu({ open, levels, progress, activeLevelId, onSelectLevel
 function labelForStatus(status: string) {
   switch (status) {
     case 'solved':
-      return 'Risolto';
+      return 'Solved';
     case 'failed':
-      return 'Finito';
+      return 'Finished';
     case 'playing':
-      return 'In corso';
+      return 'In progress';
     default:
-      return 'Nuovo';
+      return 'New';
   }
 }

--- a/src/components/StatsScreen.tsx
+++ b/src/components/StatsScreen.tsx
@@ -28,14 +28,14 @@ export function StatsScreen({
     <main className="page stats-page">
       <section className="stats-hero glass-card">
         <div>
-          <p className="eyebrow">I tuoi progressi</p>
-          <h2>Statistiche</h2>
+          <p className="eyebrow">Your progress</p>
+          <h2>Stats</h2>
           <p className="muted">
-            Puoi entrare in qualunque livello. Se un livello è in corso, rientri esattamente dove avevi lasciato.
+            You can enter any level. If a level is in progress, you return exactly where you left off.
           </p>
         </div>
         <button className="ghost-button" type="button" onClick={onBack}>
-          Torna al gioco
+          Back to game
         </button>
       </section>
 
@@ -45,28 +45,28 @@ export function StatsScreen({
         </div>
       ) : null}
 
-      <section className="stats-grid" aria-label="Statistiche principali">
-        <StatBox label="Completamento" value={`${stats.completionPct}%`} />
-        <StatBox label="Risolti" value={`${stats.solved}/${stats.total}`} />
-        <StatBox label="Falliti" value={String(stats.failed)} />
-        <StatBox label="In corso" value={String(stats.playing)} />
-        <StatBox label="Tentativi usati" value={String(stats.usedAttempts)} />
-        <StatBox label="Streak iniziale" value={String(stats.streak)} />
+      <section className="stats-grid" aria-label="Main stats">
+        <StatBox label="Completion" value={`${stats.completionPct}%`} />
+        <StatBox label="Solved" value={`${stats.solved}/${stats.total}`} />
+        <StatBox label="Failed" value={String(stats.failed)} />
+        <StatBox label="In progress" value={String(stats.playing)} />
+        <StatBox label="Attempts used" value={String(stats.usedAttempts)} />
+        <StatBox label="Opening streak" value={String(stats.streak)} />
       </section>
 
       <section className="glass-card tools-card">
         <div>
-          <h3>Salvataggio</h3>
+          <h3>Saving</h3>
           <p className="muted">
-            La app usa IndexedDB nel browser. Esporta il JSON se vuoi spostare i progressi su un altro dispositivo.
+            Export the JSON if you want to move your progress to another device.
           </p>
         </div>
         <div className="toolbar">
           <button className="primary-button" type="button" onClick={onExport}>
-            Esporta JSON
+            Export JSON
           </button>
           <button className="ghost-button" type="button" onClick={() => inputRef.current?.click()}>
-            Importa JSON
+            Import JSON
           </button>
           <button className="danger-button" type="button" onClick={onReset}>
             Reset
@@ -85,7 +85,7 @@ export function StatsScreen({
         </div>
       </section>
 
-      <section className="history-list" aria-label="Lista livelli">
+      <section className="history-list" aria-label="Level list">
         {levels.map((level, index) => {
           const levelProgress = progress.levels[level.id] ?? createEmptyLevelProgress();
           return (
@@ -96,13 +96,13 @@ export function StatsScreen({
               onClick={() => onSelectLevel(level.id)}
             >
               <span className="history-main">
-                <strong>Livello {index + 1}</strong>
+                <strong>Level {index + 1}</strong>
                 <small>{labelForStatus(levelProgress.status)}</small>
               </span>
               <span className="history-meta">
                 {levelProgress.status === 'playing'
-                  ? `Usati ${levelProgress.attemptsUsed}/4 · Immagine ${levelProgress.currentPanelIndex + 1}`
-                  : `Tentativi ${levelProgress.attemptsUsed}/4`}
+                  ? `Used ${levelProgress.attemptsUsed}/4 · Image ${levelProgress.currentPanelIndex + 1}`
+                  : `Attempts ${levelProgress.attemptsUsed}/4`}
               </span>
             </button>
           );
@@ -124,12 +124,12 @@ function StatBox({ label, value }: { label: string; value: string }) {
 function labelForStatus(status: string) {
   switch (status) {
     case 'solved':
-      return 'Risolto';
+      return 'Solved';
     case 'failed':
-      return 'Concluso senza soluzione';
+      return 'Finished without solving';
     case 'playing':
-      return 'In corso';
+      return 'In progress';
     default:
-      return 'Non iniziato';
+      return 'Not started';
   }
 }

--- a/src/domain/gameEngine.ts
+++ b/src/domain/gameEngine.ts
@@ -129,7 +129,7 @@ export function submitAnswer(level: Level, progress: LevelProgress, answer: stri
       progress,
       correct: true,
       consumedAttempt: false,
-      message: 'Livello già risolto: puoi rivederlo, ma non consumare altri tentativi.'
+      message: 'Level already solved: you can review it, but you cannot spend more attempts.'
     };
   }
 
@@ -138,7 +138,7 @@ export function submitAnswer(level: Level, progress: LevelProgress, answer: stri
       progress,
       correct: false,
       consumedAttempt: false,
-      message: 'Livello già concluso: i 4 tentativi sono stati usati.'
+      message: 'Level already finished: all 4 attempts have been used.'
     };
   }
 
@@ -147,7 +147,7 @@ export function submitAnswer(level: Level, progress: LevelProgress, answer: stri
       progress: finalizeLevel(progress, 'failed', null),
       correct: false,
       consumedAttempt: false,
-      message: 'Tentativi terminati.'
+      message: 'No attempts left.'
     };
   }
 
@@ -187,7 +187,7 @@ export function submitAnswer(level: Level, progress: LevelProgress, answer: stri
       ),
       correct: true,
       consumedAttempt: true,
-      message: `Corretto! Risolto in ${attemptNumber}/4 tentativi.`
+      message: `Correct! Solved in ${attemptNumber}/4 attempts.`
     };
   }
 
@@ -204,7 +204,7 @@ export function submitAnswer(level: Level, progress: LevelProgress, answer: stri
       ),
       correct: false,
       consumedAttempt: true,
-      message: 'Risposta sbagliata. I 4 tentativi sono finiti.'
+      message: 'Wrong answer. All 4 attempts are gone.'
     };
   }
 
@@ -218,7 +218,7 @@ export function submitAnswer(level: Level, progress: LevelProgress, answer: stri
     },
     correct: false,
     consumedAttempt: true,
-    message: `Risposta sbagliata. Tentativo ${attemptNumber}/4 consumato.`
+    message: `Wrong answer. Attempt ${attemptNumber}/4 used.`
   };
 }
 

--- a/src/persistence/createProgressStore.ts
+++ b/src/persistence/createProgressStore.ts
@@ -17,7 +17,7 @@ class ResilientProgressStore implements ProgressStore {
     try {
       return await this.primary.load();
     } catch (error) {
-      console.warn('IndexedDB non disponibile, uso localStorage fallback.', error);
+      console.warn('IndexedDB unavailable, using localStorage fallback.', error);
       this.useFallback = true;
       return this.fallback.load();
     }
@@ -28,7 +28,7 @@ class ResilientProgressStore implements ProgressStore {
     try {
       return await this.primary.save(progress);
     } catch (error) {
-      console.warn('Salvataggio IndexedDB fallito, uso localStorage fallback.', error);
+      console.warn('IndexedDB save failed, using localStorage fallback.', error);
       this.useFallback = true;
       return this.fallback.save(progress);
     }
@@ -39,7 +39,7 @@ class ResilientProgressStore implements ProgressStore {
     try {
       return await this.primary.clear();
     } catch (error) {
-      console.warn('Reset IndexedDB fallito, uso localStorage fallback.', error);
+      console.warn('IndexedDB reset failed, using localStorage fallback.', error);
       this.useFallback = true;
       return this.fallback.clear();
     }
@@ -54,7 +54,7 @@ class ResilientProgressStore implements ProgressStore {
     try {
       return await this.primary.importJson(jsonText);
     } catch (error) {
-      console.warn('Import IndexedDB fallito, uso localStorage fallback.', error);
+      console.warn('IndexedDB import failed, using localStorage fallback.', error);
       this.useFallback = true;
       return this.fallback.importJson(jsonText);
     }

--- a/src/persistence/progressStore.ts
+++ b/src/persistence/progressStore.ts
@@ -11,8 +11,8 @@ export interface ProgressStore {
 
 const INTEGRITY_PREFIX = 'gtm-modern-local-integrity-v1';
 
-// Nota anti-cheat: questa firma serve a scoprire alterazioni accidentali o casuali del salvataggio.
-// Non è sicurezza crittografica forte, perché in una app 100% client-side anche il codice è nelle mani dell'utente.
+// Anti-cheat note: this signature detects accidental or casual save tampering.
+// It is not strong cryptographic security, because in a 100% client-side app the code is also in the user's hands.
 export async function signProgress(progress: PlayerProgress): Promise<string> {
   const clean: PlayerProgress = {
     ...progress,
@@ -27,8 +27,8 @@ export async function signProgress(progress: PlayerProgress): Promise<string> {
     return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
   }
 
-  // Fallback non crittografico per contesti legacy: mantiene il rilevamento soft di modifiche,
-  // ma non va considerato anti-cheat forte.
+  // Non-cryptographic fallback for legacy contexts: keeps soft tamper detection,
+  // but it must not be considered strong anti-cheat.
   let hash = 2166136261;
   for (let i = 0; i < input.length; i += 1) {
     hash ^= input.charCodeAt(i);
@@ -58,7 +58,7 @@ export async function verifyIntegrity(progress: PlayerProgress): Promise<PlayerP
   return {
     ...progress,
     integrityWarning:
-      'Il salvataggio locale non coincide con la firma di integrità. Potrebbe essere stato modificato fuori dalla app.'
+      'The local save does not match the integrity signature. It may have been changed outside the app.'
   };
 }
 
@@ -86,7 +86,7 @@ export function exportDocument(progress: PlayerProgress): string {
 
 export function parseImport(jsonText: string): PlayerProgress {
   const parsed = JSON.parse(jsonText) as unknown;
-  if (!parsed || typeof parsed !== 'object') throw new Error('File JSON non valido.');
+  if (!parsed || typeof parsed !== 'object') throw new Error('Invalid JSON file.');
 
   const maybeDocument = parsed as Partial<PersistedDocument> & Partial<PlayerProgress>;
   const progress = maybeDocument.progress ?? maybeDocument;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,20 +4,40 @@
   --white: #ffffff;
   --purple: #6200ea;
   --purple-deep: #3700b3;
+  --purple-primary: #7c3cff;
+  --purple-hover: #9463ff;
+  --purple-active: #5422cc;
+  --purple-glow: #b388ff;
+  --purple-subtle: #180a2f;
+  --accent-reward: #35f2a0;
+  --accent-reward-deep: #0fbf7a;
+  --accent-mystery: #ffb238;
+  --accent-mystery-deep: #d67d00;
+  --bg-void: #000000;
+  --bg-night: #08030f;
+  --bg-orbit: #120522;
+  --bg-panel: #17111f;
   --panel: #333333;
-  --panel-soft: rgba(51, 51, 51, 0.82);
-  --panel-strong: rgba(20, 20, 24, 0.92);
-  --line: rgba(255, 255, 255, 0.14);
-  --muted: rgba(255, 255, 255, 0.72);
-  --danger: #ff4d4d;
-  --success: #1db954;
-  --shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  --panel-soft: rgba(23, 17, 31, 0.86);
+  --panel-strong: rgba(10, 5, 18, 0.94);
+  --line: rgba(229, 221, 255, 0.16);
+  --line-strong: rgba(179, 136, 255, 0.32);
+  --text-primary: #f7f2ff;
+  --text-secondary: #c9b8ef;
+  --text-muted: #8f82aa;
+  --text-disabled: #5b526d;
+  --text-inverse: #09040f;
+  --danger: #ff5c7a;
+  --success: var(--accent-reward);
+  --warning: var(--accent-mystery);
+  --muted: var(--text-secondary);
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.58);
   --radius-lg: 28px;
   --radius-md: 18px;
   --radius-sm: 12px;
   --header-h: 72px;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: var(--black);
+  background: var(--bg-void);
 }
 
 * {
@@ -25,19 +45,18 @@
 }
 
 html {
-  background: var(--black);
+  background: var(--bg-void);
 }
 
 body {
   min-width: 320px;
   min-height: 100dvh;
   margin: 0;
-  color: var(--white);
+  color: var(--text-primary);
   background:
-    radial-gradient(circle at 18% 10%, rgba(98, 0, 234, 0.36), transparent 34rem),
-    radial-gradient(circle at 86% 18%, rgba(98, 0, 234, 0.18), transparent 28rem),
-    linear-gradient(135deg, rgba(98, 0, 234, 0.1), transparent 44%),
-    var(--black);
+    radial-gradient(circle at 16% 8%, rgba(124, 60, 255, 0.34), transparent 34rem),
+    radial-gradient(circle at 88% 14%, rgba(255, 178, 56, 0.14), transparent 26rem),
+    linear-gradient(140deg, var(--bg-void) 0%, var(--bg-night) 38%, var(--bg-orbit) 100%);
   overflow-x: hidden;
 }
 
@@ -86,7 +105,7 @@ img {
   justify-content: space-between;
   gap: 1rem;
   padding: max(0.85rem, env(safe-area-inset-top)) clamp(1rem, 3vw, 2rem) 0.85rem;
-  background: linear-gradient(90deg, rgba(98, 0, 234, 0.95), rgba(55, 0, 179, 0.95));
+  background: linear-gradient(92deg, rgba(8, 3, 15, 0.92) 0%, rgba(55, 0, 179, 0.88) 48%, rgba(124, 60, 255, 0.86) 100%);
   border-bottom: 1px solid rgba(255,255,255,0.16);
   box-shadow: 0 12px 40px rgba(0,0,0,0.34);
   backdrop-filter: blur(18px);
@@ -116,7 +135,7 @@ img {
   font-size: 0.72rem;
   letter-spacing: 0.13em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.72);
+  color: var(--text-secondary);
 }
 
 h1,
@@ -190,7 +209,7 @@ h3 {
   inset: auto -10% -22% auto;
   width: 22rem;
   aspect-ratio: 1;
-  background: radial-gradient(circle, rgba(98,0,234,0.36), transparent 68%);
+  background: radial-gradient(circle, rgba(179,136,255,0.3), transparent 68%);
   pointer-events: none;
 }
 
@@ -225,13 +244,13 @@ h3 {
 }
 
 .status-pill.solved {
-  background: rgba(29, 185, 84, 0.17);
-  border-color: rgba(29, 185, 84, 0.45);
+  background: rgba(53, 242, 160, 0.16);
+  border-color: rgba(53, 242, 160, 0.46);
 }
 
 .status-pill.failed {
-  background: rgba(255, 77, 77, 0.17);
-  border-color: rgba(255, 77, 77, 0.45);
+  background: rgba(255, 92, 122, 0.16);
+  border-color: rgba(255, 92, 122, 0.46);
 }
 
 .attempts {
@@ -252,18 +271,18 @@ h3 {
 }
 
 .attempt-dot.used {
-  background: var(--purple);
-  box-shadow: 0 0 20px rgba(98,0,234,0.65);
+  background: var(--purple-primary);
+  box-shadow: 0 0 20px rgba(179,136,255,0.62);
 }
 
 .attempt-dot.used.solved {
   background: var(--success);
-  box-shadow: 0 0 20px rgba(29,185,84,0.45);
+  box-shadow: 0 0 20px rgba(53,242,160,0.45);
 }
 
 .attempt-dot.used.failed {
   background: var(--danger);
-  box-shadow: 0 0 20px rgba(255,77,77,0.45);
+  box-shadow: 0 0 20px rgba(255,92,122,0.45);
 }
 
 .panel-counter,
@@ -280,8 +299,8 @@ h3 {
   border-radius: var(--radius-lg);
   border: 1px solid rgba(255,255,255,0.12);
   background:
-    radial-gradient(circle at 50% 0%, rgba(98,0,234,0.24), transparent 52%),
-    rgba(0,0,0,0.36);
+    radial-gradient(circle at 50% 0%, rgba(124,60,255,0.24), transparent 52%),
+    linear-gradient(180deg, rgba(18,5,34,0.62), rgba(0,0,0,0.42));
   overflow: hidden;
 }
 
@@ -320,10 +339,10 @@ h3 {
   max-width: min(88%, 38rem);
   padding: 0.78rem 0.9rem;
   border-radius: 1rem;
-  background: rgba(98, 0, 234, 0.84);
-  border: 1px solid rgba(255,255,255,0.2);
-  box-shadow: 0 12px 30px rgba(0,0,0,0.38);
-  color: var(--white);
+  background: rgba(255, 178, 56, 0.2);
+  border: 1px solid rgba(255, 178, 56, 0.42);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.38), 0 0 28px rgba(255,178,56,0.14);
+  color: var(--text-primary);
   font-weight: 750;
   backdrop-filter: blur(10px);
 }
@@ -345,7 +364,7 @@ h3 {
 .progress-rail span {
   inset-inline-start: 0;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--purple), #8d4dff);
+  background: linear-gradient(90deg, var(--purple-primary), var(--accent-reward));
   transition: inline-size 240ms ease;
 }
 
@@ -361,11 +380,11 @@ h3 {
 }
 
 .result-message.ok {
-  color: #67ff9a;
+  color: var(--accent-reward);
 }
 
 .result-message.no {
-  color: #ff8a8a;
+  color: var(--danger);
 }
 
 .guess-form {
@@ -382,13 +401,13 @@ h3 {
   border: 1px solid var(--line);
   outline: none;
   background: rgba(0,0,0,0.36);
-  color: var(--white);
+  color: var(--text-primary);
   transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .guess-form input:focus {
-  border-color: rgba(98, 0, 234, 0.9);
-  box-shadow: 0 0 0 4px rgba(98,0,234,0.22);
+  border-color: rgba(148, 99, 255, 0.95);
+  box-shadow: 0 0 0 4px rgba(124,60,255,0.24);
   background: rgba(0,0,0,0.5);
 }
 
@@ -399,16 +418,16 @@ h3 {
   min-height: 2.75rem;
   border: 0;
   border-radius: var(--radius-sm);
-  color: var(--white);
+  color: var(--text-primary);
   font-weight: 850;
   cursor: pointer;
-  transition: transform 120ms ease, background 160ms ease, border-color 160ms ease, opacity 160ms ease;
+  transition: transform 120ms ease, background 160ms ease, border-color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
 
 .primary-button {
   padding: 0.75rem 1rem;
-  background: linear-gradient(135deg, var(--purple), var(--purple-deep));
-  box-shadow: 0 16px 34px rgba(98,0,234,0.36);
+  background: linear-gradient(135deg, var(--purple-primary), var(--purple-deep));
+  box-shadow: none;
 }
 
 .ghost-button {
@@ -434,8 +453,8 @@ h3 {
 
 .danger-button {
   padding: 0.72rem 0.9rem;
-  background: rgba(255, 77, 77, 0.18);
-  border: 1px solid rgba(255, 77, 77, 0.38);
+  background: rgba(255, 92, 122, 0.18);
+  border: 1px solid rgba(255, 92, 122, 0.38);
 }
 
 .primary-button:not(:disabled):hover,
@@ -445,11 +464,20 @@ h3 {
   transform: translateY(-1px);
 }
 
+.primary-button:not(:disabled):hover {
+  background: linear-gradient(135deg, var(--purple-hover), var(--purple-primary));
+  box-shadow: none;
+}
+
 .primary-button:not(:disabled):active,
 .ghost-button:not(:disabled):active,
 .icon-button:not(:disabled):active,
 .danger-button:not(:disabled):active {
   transform: translateY(1px) scale(0.99);
+}
+
+.primary-button:not(:disabled):active {
+  background: linear-gradient(135deg, var(--purple-active), var(--purple-deep));
 }
 
 .controls-row {
@@ -488,7 +516,7 @@ h3 {
   padding: 1rem;
   overflow: auto;
   background:
-    radial-gradient(circle at 15% 0%, rgba(98,0,234,0.26), transparent 26rem),
+    radial-gradient(circle at 15% 0%, rgba(124,60,255,0.26), transparent 26rem),
     var(--panel-strong);
   border-left: 1px solid var(--line);
   box-shadow: -24px 0 80px rgba(0,0,0,0.55);
@@ -538,7 +566,7 @@ h3 {
 .history-row {
   width: 100%;
   border: 1px solid var(--line);
-  color: var(--white);
+  color: var(--text-primary);
   background: rgba(255,255,255,0.07);
   text-align: left;
   cursor: pointer;
@@ -557,12 +585,12 @@ h3 {
 .history-row:hover {
   transform: translateY(-1px);
   background: rgba(255,255,255,0.1);
-  border-color: rgba(98,0,234,0.7);
+  border-color: rgba(148,99,255,0.72);
 }
 
 .level-card.active {
-  border-color: rgba(98,0,234,0.95);
-  box-shadow: inset 0 0 0 1px rgba(98,0,234,0.55), 0 0 34px rgba(98,0,234,0.18);
+  border-color: rgba(179,136,255,0.92);
+  box-shadow: inset 0 0 0 1px rgba(124,60,255,0.55), 0 0 34px rgba(179,136,255,0.2);
 }
 
 .level-number {
@@ -572,7 +600,7 @@ h3 {
   width: 2.55rem;
   height: 2.55rem;
   border-radius: 0.9rem;
-  background: rgba(98,0,234,0.36);
+  background: rgba(124,60,255,0.28);
   font-weight: 900;
 }
 
@@ -634,9 +662,9 @@ h3 {
 .warning-card {
   padding: 0.9rem 1rem;
   border-radius: var(--radius-md);
-  color: #fff5d7;
-  background: rgba(255, 178, 36, 0.18);
-  border: 1px solid rgba(255, 178, 36, 0.38);
+  color: #fff2d1;
+  background: rgba(255, 178, 56, 0.16);
+  border: 1px solid rgba(255, 178, 56, 0.4);
 }
 
 .history-list {
@@ -692,7 +720,7 @@ h3 {
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: rgba(16,16,18,0.96);
+  background: rgba(10,5,18,0.96);
   box-shadow: var(--shadow);
 }
 
@@ -712,8 +740,8 @@ h3 {
   aspect-ratio: 1;
   border: 1px solid rgba(255,255,255,0.2);
   border-radius: 999px;
-  background: rgba(98,0,234,0.9);
-  color: var(--white);
+  background: rgba(124,60,255,0.9);
+  color: var(--text-primary);
   font-weight: 900;
   cursor: pointer;
 }
@@ -732,7 +760,7 @@ h3 {
   aspect-ratio: 1;
   border-radius: 50%;
   border: 4px solid rgba(255,255,255,0.15);
-  border-top-color: var(--purple);
+  border-top-color: var(--purple-glow);
   animation: spin 800ms linear infinite;
 }
 
@@ -804,7 +832,7 @@ h3 {
     bottom: 0;
     z-index: 5;
     padding: 0.55rem 0 0;
-    background: linear-gradient(to top, rgba(36,36,38,0.96), rgba(36,36,38,0.72), transparent);
+    background: linear-gradient(to top, rgba(10,5,18,0.96), rgba(18,5,34,0.72), transparent);
   }
 
   .controls-row .ghost-button {

--- a/src/test/gameEngine.test.ts
+++ b/src/test/gameEngine.test.ts
@@ -5,7 +5,7 @@ import { createEmptyLevelProgress, submitAnswer } from '../domain/gameEngine';
 const level = levels[0];
 
 describe('game engine', () => {
-  it('consuma un tentativo anche con risposta vuota e avanza alla seconda immagine', () => {
+  it('consumes an attempt even with an empty answer and advances to the second image', () => {
     const result = submitAnswer(level, createEmptyLevelProgress(), '');
 
     expect(result.consumedAttempt).toBe(true);
@@ -15,7 +15,7 @@ describe('game engine', () => {
     expect(result.progress.maxPanelUnlocked).toBe(1);
   });
 
-  it('non permette più di quattro tentativi reali', () => {
+  it('does not allow more than four real attempts', () => {
     let progress = createEmptyLevelProgress();
 
     for (let i = 0; i < 4; i += 1) {
@@ -28,7 +28,7 @@ describe('game engine', () => {
     expect(extra.progress.attemptsUsed).toBe(4);
   });
 
-  it('accetta varianti normalizzate della risposta', () => {
+  it('accepts normalized answer variants', () => {
     const result = submitAnswer(level, createEmptyLevelProgress(), '  NÀRUTO!! ');
 
     expect(result.correct).toBe(true);
@@ -36,7 +36,7 @@ describe('game engine', () => {
     expect(result.progress.attemptsUsed).toBe(1);
   });
 
-  it('sblocca tutte le immagini quando il livello finisce', () => {
+  it('unlocks all images when the level ends', () => {
     const result = submitAnswer(level, createEmptyLevelProgress(), 'Naruto');
     expect(result.progress.maxPanelUnlocked).toBe(3);
   });


### PR DESCRIPTION
### Motivation
- Move the app UI and user-facing runtime messages from Italian to English for broader accessibility. 
- Refresh the visual theme with refined color tokens and improved component styles for a more polished dark look.
- Make internal persistence/log messages and integrity notes clearer in English.

### Description
- Translate UI strings and ARIA labels across templates and components including `index.html`, `Header`, `GameScreen`, `LevelMenu`, `StatsScreen`, and `ImageModal` from Italian to English. 
- Localize runtime messages in the game engine and persistence layer such as the `submitAnswer` messages, `createProgressStore` console warnings, and integrity warnings in `progressStore.ts`. 
- Update `createProgressStore.ts` to prefer IndexedDB but fall back with clearer English console warnings when needed. 
- Revamp the theme in `src/styles/index.css` by introducing new CSS variables (accent, background, text tokens), adjusting gradients, button hover/active states, and visual details for panels, hints, progress rail, and modal styling. 
- Update unit test strings in `src/test/gameEngine.test.ts` to English to match the localized messages.

### Testing
- Ran the unit test suite with `vitest`, including `src/test/gameEngine.test.ts`, and all tests passed. 
- No regressions reported by the unit tests after translation and style changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439f1f7e948328a8f84ff202702cbf)