### PR TITLE
Refine button glow and hint readability

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -339,11 +339,17 @@ h3 {
   max-width: min(88%, 38rem);
   padding: 0.78rem 0.9rem;
   border-radius: 1rem;
-  background: rgba(255, 178, 56, 0.2);
-  border: 1px solid rgba(255, 178, 56, 0.42);
-  box-shadow: 0 12px 30px rgba(0,0,0,0.38), 0 0 28px rgba(255,178,56,0.14);
-  color: var(--text-primary);
+  background: rgba(26, 11, 51, 0.78);
+  border: 1px solid rgba(148, 99, 255, 0.64);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.42);
+  color: var(--white);
   font-weight: 750;
+  text-shadow:
+    -1px -1px 0 rgba(0,0,0,0.72),
+    1px -1px 0 rgba(0,0,0,0.72),
+    -1px 1px 0 rgba(0,0,0,0.72),
+    1px 1px 0 rgba(0,0,0,0.72),
+    0 2px 4px rgba(0,0,0,0.9);
   backdrop-filter: blur(10px);
 }
 
@@ -364,7 +370,7 @@ h3 {
 .progress-rail span {
   inset-inline-start: 0;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--purple-primary), var(--accent-reward));
+  background: linear-gradient(90deg, var(--purple-primary), #2778ff);
   transition: inline-size 240ms ease;
 }
 
@@ -427,7 +433,7 @@ h3 {
 .primary-button {
   padding: 0.75rem 1rem;
   background: linear-gradient(135deg, var(--purple-primary), var(--purple-deep));
-  box-shadow: 0 16px 34px rgba(124,60,255,0.36), 0 0 28px rgba(179,136,255,0.16);
+  box-shadow: none;
 }
 
 .ghost-button {
@@ -466,7 +472,7 @@ h3 {
 
 .primary-button:not(:disabled):hover {
   background: linear-gradient(135deg, var(--purple-hover), var(--purple-primary));
-  box-shadow: 0 18px 38px rgba(148,99,255,0.4), 0 0 32px rgba(179,136,255,0.2);
+  box-shadow: none;
 }
 
 .primary-button:not(:disabled):active,


### PR DESCRIPTION
### Motivation
- Improve on-image hint legibility for long hints that overlap panels and make buttons visually flatter to reduce distracting glow.
- Move the progress indicator away from a purple-to-green aesthetic toward a purple-to-blue fill that better matches the intended palette.

### Description
- Updated `src/styles/index.css` to restyle `.hint-overlay` with a darker translucent purple background, a purple border, stronger drop shadow, and a multi-directional text shadow to improve contrast of white hint text over images.
- Removed the glowing box-shadow from `.primary-button` and its hover state so controls like Submit and Export JSON no longer show the bright glow effect.
- Changed the progress bar fill from `linear-gradient(90deg, var(--purple-primary), var(--accent-reward))` to `linear-gradient(90deg, var(--purple-primary), #2778ff)` to go from purple toward blue instead of green.

### Testing
- Ran `npm run test` and all tests passed (`4` tests in `1` file).
- Ran `npm run build` which completed successfully and produced the production assets. 
- Attempted an automated Playwright screenshot but it failed to run in this environment because the Playwright browser binaries were not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44cbe9555483289744183ce90498cb)